### PR TITLE
Remove dependency to external queue persistence, use only redis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This is a proof of concept that demonstrates that distributing processes in a Ze
 This initial library code is not yet unit tested.
 
 ### pre-requisite
-This relies on zerv-core and zerv-sync libraries and redis.
+This relies on both zerv-core and zerv-sync libraries as well as redis to store the process queue.
 
 ### Principle
 In order to free resources on the main socket servers (public facing application servers), zerv can easily distribute the load on the zerv cluster.
@@ -79,14 +79,7 @@ function updateOpportunityPermissions(tenantId, processHandle, params) {
 
 __setCustomProcessImpl(processService)__
 
-The library functionalities rely on accessing a queue. The queue implements a Redis lock mechanism to prevent multiple servers to launch the same process. the queue persistence must be implemented in processService with the following functions:
-    createOne,
-    updateOne,
-    findOneByTenantIdAndProcessId,
-    findOneByTenantIdAndTypeAndNameAndInStatusList,
-    findAllInStatusListAndInProcessTypeList,
-    findAll.
-
+@deprecated
 More details will be added about this.
 
 __monitorQueue(serverUnigName, port, capacity)__

--- a/lib/process-monitor-client.service.js
+++ b/lib/process-monitor-client.service.js
@@ -2,12 +2,14 @@ const _ = require('lodash');
 
 const zlog = require('zlog4js');
 const moment = require('moment');
-let processService, zerv;
+const processService = require('./process.service');
+
+let zerv;
 
 const logger = zlog.getLogger('zerv/process-monitor/client');
 
 module.exports = {
-  setProcessService,
+  setZervDependency,
   submitProcess,
   waitForCompletion,
 };
@@ -20,8 +22,7 @@ module.exports = {
  * A default implementation should be implemented based on Redis
  * optional Listeners (onProcessCreation, onProcessCompletion, etc) should be implemented
  */
-function setProcessService(impl, zervInstance) {
-  processService = impl;
+function setZervDependency(zervInstance) {
   zerv = zervInstance;
   listenToTenantProcessData();
 }
@@ -73,7 +74,10 @@ function listenToTenantProcessData() {
  * @returns {TenantProcess} the process that was started or the existing process
  */
 async function submitProcess(tenantId, type, name, params, options = {}) {
-  const existingActiveProcess = await processService.findOneByTenantIdAndTypeAndNameAndInStatusList(tenantId, type, name, [processService.PROCESS_STATUSES.PENDING, processService.PROCESS_STATUSES.IN_PROGRESS]);
+  if (!zerv.getRedisClient()) {
+    throw new Error('REDIS_DISABLED');
+  }
+  const existingActiveProcess = await processService.findOneByTenantIdAndTypeAndNameAndInProgressOrPending(tenantId, type, name);
 
   if (existingActiveProcess && existingActiveProcess.single) {
     // Only one process runs enterprise wide with this exact tenantId, type and name

--- a/lib/process-monitor-server.service.js
+++ b/lib/process-monitor-server.service.js
@@ -2,29 +2,27 @@ const assert = require('assert');
 const _ = require('lodash');
 const zlog = require('zlog4js');
 const moment = require('moment');
-const ip = require('ip');
-const IoRedis = require('ioredis');
 const ioRedisLock = require('ioredis-lock');
 const serverStatusService = require('./server-status.service');
+const processService = require('./process.service');
+
 
 const logger = zlog.getLogger('process-monitor/server');
 
 const supportedProcessTypes = {};
-let processService, zerv;
-let serverUniqId = 'UndefinedServerId';
+let zerv;
 const activeProcesses = {};
-let redisClient;
 let waitForProcessingQueue;
+const thisServerStart = new Date();
 
 module.exports = {
-  setProcessService,
+  setZervDependency,
   monitorQueue,
   addProcessType,
-  getServerId,
+  getServerId: serverStatusService.getServerId
 };
 
-function setProcessService(impl, zervInstance) {
-  processService = impl;
+function setZervDependency(zervInstance) {
   zerv = zervInstance;
 }
 
@@ -59,9 +57,6 @@ function addProcessType(type, executeFn, options) {
   supportedProcessTypes[type] = _.assign({ execute }, options);
 }
 
-function getServerId() {
-  return serverUniqId;
-}
 
 /**
  * This function starts the process queue monitor
@@ -74,17 +69,17 @@ function getServerId() {
  * @param {Number} capacityProfile the number of processes the server can run at the same time
  */
 function monitorQueue(serverName, port, capacityProfile) {
+  if (_.isEmpty(capacityProfile)) {
+    capacityProfile = Number(process.env.ZERV_MAX_PROCESS_CAPACITY || 30);
+  }
   assert(_.isNumber(capacityProfile) && capacityProfile>=0 && capacityProfile<10000, 'The capacity is invalid');
-  serverUniqId = `${serverName}/${ip.address()}:${port}`;
-
   // ZERV_STAY_ALIVE is the duration before server is no longer considered alive by the cluster
-  serverStatusService.createOne(serverUniqId, process.env.ZERV_STAY_ALIVE || 30);
-
+  serverStatusService.createOne(serverName, process.env.ZERV_STAY_ALIVE || 30);
   // if there is no capacity or process type supported. monitor does NOT listen to the queue
-  if (capacityProfile > 0 && _.keys(supportedProcessTypes).length) {
+  if (zerv.getRedisClient() && capacityProfile > 0 && _.keys(supportedProcessTypes).length) {
     listenProcessQueueForNewRequests(capacityProfile);
   }
-  notifyServerStatusPeriodically();
+  serverStatusService.notifyServerStatusPeriodically();
 }
 
 
@@ -94,21 +89,11 @@ function monitorQueue(serverName, port, capacityProfile) {
  * @returns {Object} with a release function to release the lock.
  */
 async function getLock() {
-  if (process.env.REDIS_ENABLED !== 'true') {
-    return { release: _.noop}; ;
+  if (!zerv.getRedisClient()) {
+    return { release: _.noop};
   }
-  if (!redisClient) {
-    // --------------------------
-    // Later on, let's use instead the redis client initalized in zerv-sync/clustering
-    // if there were any error, zerv-sync will throw errors anyway
-    const connectionParams = {
-      port: process.env.REDIS_PORT || 6379,
-      host: process.env.REDIS_HOST || '127.0.0.1',
-    };
-    redisClient = new IoRedis(connectionParams);
-    // --------------------------
-  }
-  const processQueueResisLock = ioRedisLock.createLock(redisClient, {
+
+  const processQueueResisLock = ioRedisLock.createLock(zerv.getRedisClient(), {
     timeout: process.env.REDIS_LOCK_TIMEOUT_IN_MS || 20000,
     // retries should be based on how many servers running and how busy is the sytem
     // since many processes will try to acquire the lock at the same time on a busy system
@@ -133,7 +118,7 @@ async function getLock() {
 
 
 function listenProcessQueueForNewRequests(capacityProfile) {
-  logger.info('Server %b is monitoring process queue for executing processes %b. max capacity: %s', serverUniqId, _.keys(supportedProcessTypes), capacityProfile);
+  logger.info('Server %b is monitoring process queue for executing processes %b. max capacity: %s', serverStatusService.getServerId(), _.keys(supportedProcessTypes), capacityProfile);
 
   zerv.onChanges('TENANT_PROCESS_DATA', async (tenantId, process, notificationType) => {
     if (process.status === processService.PROCESS_STATUSES.PENDING) {
@@ -184,17 +169,6 @@ function scheduleToCheckForNewProcessResquests(capacityProfile) {
   }
 }
 
-
-function notifyServerStatusPeriodically(thisServerStatus) {
-  setInterval(() => {
-    const serverStatus = serverStatusService.findByServerId(getServerId());
-    serverStatus.activeProcesses= zerv.getActivitiesInProcess();
-    serverStatus.userSessions = zerv.getLocalUserSessions();
-    serverStatusService.updateOne(serverStatus);
-  }, serverStatusService.findByServerId(getServerId()).timeout*1000/2);
-}
-
-
 async function runNextProcesses(capacityProfile) {
   let done;
   waitForProcessingQueue = new Promise((resolve) => {
@@ -204,14 +178,14 @@ async function runNextProcesses(capacityProfile) {
   if (isServerShuttingDown()) {
     return;
   }
-  const nextProcessesToRun = await selectNextProcessesToRun(serverUniqId, capacityProfile || 1);
+  const nextProcessesToRun = await selectNextProcessesToRun(serverStatusService.getServerId(), capacityProfile || 1);
   done();
   waitForProcessingQueue = null;
 
   const runningProcesses = _.map(nextProcessesToRun, async (process) => {
     try {
       activeProcesses[process.id] = process;
-      await executeProcess(process, serverUniqId);
+      await executeProcess(process, serverStatusService.getServerId());
       delete activeProcesses[process.id];
     } catch (err) {
       delete activeProcesses[process.id];
@@ -264,37 +238,36 @@ async function selectNextProcessesToRun(serverId, capacityProfile) {
   const processesToExecute = [];
   try {
     const lock = await getLock();
-    await zerv.startTransaction({ name: 'selectNextProcessToRun on ' + serverId })
-        .execute(async (transaction) => {
-          // the queue returns all records that are not current locked by any other transaction
-          const queue = await processService.findAllPendingAndInProgressProcesses(transaction, _.keys(supportedProcessTypes));
-          // chronological order based on processe created date and status so that stalled processes show up first to be reprocessed asap
-          queue.sort((a, b) => {
-            if (a.status === processService.PROCESS_STATUSES.IN_PROGRESS && a.status !== b.status) {
-              return -1;
-            }
-            return new Date(a.timestamp.createdDate).getTime() - new Date(b.timestamp.createdDate).getTime();
-          });
 
-          logger.debug('Current Queue: ', JSON.stringify(_.map(queue, p => _.pick(p, ['type', 'name', 'status', 'serverId', 'duration'])), null, 3));
+    // the queue returns all records that are not current locked by any other transaction
+    const queue = await processService.findAllPendingAndInProgressProcesses(_.keys(supportedProcessTypes));
+    // chronological order based on processe created date and status so that stalled processes show up first to be reprocessed asap
+    queue.sort((a, b) => {
+      if (a.status === processService.PROCESS_STATUSES.IN_PROGRESS && a.status !== b.status) {
+        return -1;
+      }
+      return new Date(a.timestamp.createdDate).getTime() - new Date(b.timestamp.createdDate).getTime();
+    });
 
-          for (const process of queue) {
-            if (isServerShuttingDown() || isServerAtFullCapacity(capacityProfile)) {
-              break;
-            }
-            if ((process.status === processService.PROCESS_STATUSES.PENDING || checkIfProcessIsStalled(serverId, process)) &&
-               canServerExecuteProcessNow(process, capacityProfile)) {
-              process.status = processService.PROCESS_STATUSES.IN_PROGRESS;
-              process.start = new Date();
-              process.end = null;
-              process.serverId = serverId;
-              process.progressDescription = `Server ${serverId} will execute this process`;
-              activeProcesses[process.id] = process;
-              await processService.updateOne(process.tenantId, process, { transaction });
-              processesToExecute.push(process);
-            }
-          }
-        });
+    logger.debug('Current Queue: ', JSON.stringify(_.map(queue, p => _.pick(p, ['type', 'name', 'status', 'serverId', 'duration'])), null, 3));
+
+    for (const process of queue) {
+      if (isServerShuttingDown() || isServerAtFullCapacity(capacityProfile)) {
+        break;
+      }
+      if ((process.status === processService.PROCESS_STATUSES.PENDING || checkIfProcessIsStalled(serverId, process)) &&
+          canServerExecuteProcessNow(process, capacityProfile)) {
+        process.status = processService.PROCESS_STATUSES.IN_PROGRESS;
+        process.start = new Date();
+        process.end = null;
+        process.serverId = serverId;
+        process.progressDescription = `Server ${serverId} will execute this process`;
+        activeProcesses[process.id] = process;
+        await processService.updateOne(process.tenantId, process);
+        processesToExecute.push(process);
+      }
+    }
+
     await lock.release();
   } catch (err) {
     logger.error('Error when selecting next process to run. %s', err.message, err.stack || err);
@@ -349,21 +322,27 @@ function checkIfProcessIsStalled(serverId, process) {
 
   const serverOwner = serverStatusService.findByServerId(process.serverId);
 
-  const isCurrentProcessRunningWithinAcceptableTimeFrame =
-        // - if the process crashes, it will allow restart after the grace period.
-        // but in theory, all errors are cached, so the process will always completes one way or another. This could be needed in a cluster as a simple way to unlock crashed processes.
-        currentProcessDuration.asMinutes() < gracePeriodInMinutes &&
-        // - if the serverOwner was rebooted it means the process is stalled, and can be restarted by any server
-        // ex: if it was stopped and restarted during a sync process (ex for code upgrade), integration - which started the process -- will be able to restart right away without taking in consideration the grace period.
-        // - if the server owner is never restarted (never notifies that it is alive), the grace period will also release the process.
-        (!serverOwner || moment(serverOwner.start).isBefore(process.start) || !serverOwner.isAlive());
-
-  if (isCurrentProcessRunningWithinAcceptableTimeFrame) {
-    logger.debug('Let\'s wait for completion %b on %b. gracePeriodInMinutes is %s.', process.display, process.serverId, moment.duration(gracePeriodInMinutes, 'minutes').humanize());
-    return false;
+  // should based on last process update instead (unfortunately no all processes are updated while running)
+  if (currentProcessDuration.asMinutes() > gracePeriodInMinutes) {
+    logger.warn('The current process %b on %b seems stalled. gracePeriodInMinutes is %b. Server/Process might have crashed or interrupted. Let it restart.', process.display, process.serverId, moment.duration(gracePeriodInMinutes, 'minutes').humanize());
+    return true;
   }
-  logger.warn('The current process %b on %b seems stall. gracePeriodInMinutes is %b. Server/Process might have crashed or interrupted. Let it restart.', process.display, process.serverId, moment.duration(gracePeriodInMinutes, 'minutes').humanize());
-  return true;
+
+  if (!serverOwner) {
+    if (moment.duration(moment().diff(thisServerStart)).asSeconds() > 120) {
+      // usually servers start quickly and notify their presence.
+      logger.warn('The current process %b on %b is stalled. The server %b which started the process is offline.', process.display, process.serverId);
+      return true;
+    }
+  } else if (!moment(serverOwner.start).isBefore(process.start)) {
+    logger.warn('The current process %b on %b is stalled. The server %b which started the process was rebooted.', process.display, process.serverId);
+    return true;
+  } else if (!serverOwner.isAlive()) {
+    logger.warn('The current process %b on %b is stalled. The server %b which started the process is offline.', process.display, process.serverId);
+    return true;
+  }
+
+  return false;
 }
 
 
@@ -400,7 +379,7 @@ async function executeProcess(process, byServer) {
     logger.debug('%s: Completed successfully after %s seconds. Result: %s', process.display, process.duration, process.progressDescription);
   } catch (err) {
     process.status = processService.PROCESS_STATUSES.ERROR;
-    process.error = err;
+    process.error = _.isError(err) ? {message: err.message, description: err.description} : err;
     process.end = new Date();
     processHandle.fail(err);
     logger.error('%s: Failure after %s seconds - %s', process.display, process.duration, err.description || err.message, err.stack || err);

--- a/lib/process.service.js
+++ b/lib/process.service.js
@@ -4,6 +4,8 @@ const
   zlog = require('zlog4js');
 const moment = require('moment');
 
+const ACTIVE_QUEUE = 'zerv-active-queue';
+const INACTIVE_QUEUE = 'zerv-inactive-queue';
 const logger = zlog.getLogger('zerv/distrib/processService');
 
 const PROCESS_STATUSES = {
@@ -52,57 +54,60 @@ class TenantProcess {
 
 
 module.exports = {
-  setProcessService,
+  setZervDependency,
   purgeQueue,
   createOne,
   updateOne,
-  findOneByTenantIdAndProcessId,
-  findOneByTenantIdAndTypeAndNameAndInStatusList,
+  findOneByTenantIdAndTypeAndNameAndInProgressOrPending,
   findAllPendingAndInProgressProcesses,
   findAll,
   TenantProcess,
   PROCESS_STATUSES,
 };
 
-let processServiceImpl, zerv;
+let zerv;
 
-function setProcessService(impl, zervInstance) {
-  processServiceImpl = impl;
+function setZervDependency(zervInstance) {
   zerv = zervInstance;
 }
 
-/**
- * this retuns all processes that are pending or in progress
- * db implementation of findAllInStatusListAndInProcessTypeList should lock the rows for update
- * though a locking mechnanism is already implemented thru redis.
- * @param {ZervTransaction} transaction
- */
-async function findAllPendingAndInProgressProcesses(transaction, processTypes) {
-  const data = await processServiceImpl.findAllInStatusListAndInProcessTypeList(transaction, [PROCESS_STATUSES.PENDING, PROCESS_STATUSES.IN_PROGRESS], processTypes);
-  return _.map(data, p => new TenantProcess(p));
+
+async function findAllPendingAndInProgressProcesses(processTypes) {
+  const actives = await zerv.getRedisClient().hvals(ACTIVE_QUEUE);
+  const data = _.map(actives, p => new TenantProcess(JSON.parse(p)));
+  const result = _.filter(data, (process) => _.some(processTypes, type => process.type === type));
+  return result;
 }
 
-
-async function findAll(max) {
-  const data = await processServiceImpl.findAll(max);
-  return _.map(data, p => new TenantProcess(p));
+async function findAll() {
+  const max = process.env.ZERV_QUEUE_MAX || 1000;
+  const actives = await zerv.getRedisClient().hvals(ACTIVE_QUEUE);
+  let inactiveCount = await zerv.getRedisClient().llen(INACTIVE_QUEUE);
+  const toRemove = [];
+  while (max<inactiveCount--) {
+    toRemove.push(['lpop', INACTIVE_QUEUE]);
+  }
+  await zerv.getRedisClient().pipeline(toRemove).exec();
+  const inactives = await zerv.getRedisClient().lrange(INACTIVE_QUEUE, 0, -1);
+  const data = _.concat(actives, inactives);
+  return _.map(data, p => new TenantProcess(JSON.parse(p)));
 }
 
-async function findOneByTenantIdAndTypeAndNameAndInStatusList(tenantId, type, name, statuses) {
-  const p = await processServiceImpl.findOneByTenantIdAndTypeAndNameAndInStatusList(tenantId, type, name, statuses);
-  return _.isEmpty(p) ? null :new TenantProcess(p);
+async function findOneByTenantIdAndTypeAndNameAndInProgressOrPending(tenantId, type, name) {
+  const actives =await findAllPendingAndInProgressProcesses([type]);
+  const result = _.find(actives, (process) => process.name === name);
+  return result;
 }
-
 
 function purgeQueue(serverId, oldProcessesIds) {
-  return processServiceImpl.purgeQueue(serverId, oldProcessesIds);
+  return;
 }
 
 async function createOne(tenantId, process) {
   process.timestamp.lastModifiedDate = new Date();
   process.timestamp.createdDate = new Date();
 
-  await processServiceImpl.createOne(tenantId, process);
+  await zerv.getRedisClient().hset(ACTIVE_QUEUE, process.id, JSON.stringify(process));
 
   logger.info('Added process %b/%b to processing queue', process.type, process.name);
   // let's send the notifications to all servers so that they might execute/handle the process
@@ -111,27 +116,19 @@ async function createOne(tenantId, process) {
   return process;
 }
 
-async function updateOne(tenantId, process, options) {
+async function updateOne(tenantId, process) {
   process.revision++;
   process.timestamp.lastModifiedDate = new Date();
 
-  await processServiceImpl.updateOne(tenantId, process, options);
+  if (process.status === PROCESS_STATUSES.PENDING || process.status === PROCESS_STATUSES.IN_PROGRESS) {
+    await zerv.getRedisClient().hset(ACTIVE_QUEUE, process.id, JSON.stringify(process));
+  } else {
+    await zerv.getRedisClient().hdel(ACTIVE_QUEUE, process.id);
+    await zerv.getRedisClient().rpush(INACTIVE_QUEUE, JSON.stringify(process));
+  }
 
   logger.info('Updated process %b/%b in processing queue: %b %s', process.type, process.name, process.status, process.progressDescription);
   // let's send the notifications to all servers so that they might execute/handle the process
   zerv.notifyUpdate(tenantId, 'TENANT_PROCESS_DATA', process, {allServers: true});
   return process;
-}
-
-async function findOneByTenantIdAndProcessId(tenantTransaction, tenantId, processId) {
-  const p = await processServiceImpl.indOneByTenantIdAndProcessId(tenantTransaction, tenantId, processId);
-  return _.isEmpty(p) ? null :new TenantProcess(p);
-  // ex:
-  // Notice the row lock preventing access to this information until it is updated or transaction is completed.
-  // const queryObj = {
-  //     dbQueryString: 'SELECT doc FROM tenant_process_queue WHERE tenant_id = $1 AND id = $2 FOR UPDATE',
-  //     dbQueryParameters: [tenantId, processId],
-  //     objectClass: TenantProcess
-  // };
-  // return tenantTransaction.findOne(queryObj);
 }

--- a/lib/server-status.service.js
+++ b/lib/server-status.service.js
@@ -1,20 +1,28 @@
 
 const _ = require('lodash');
 const moment = require('moment');
+const UUID = require('uuid');
+
 
 const serverStatuses = {};
+const thisServerId = UUID.v4();
 
-module.exports = {
+const service = {
   listenToServerStatusData,
+  notifyServerStatusPeriodically,
   createOne,
   updateOne,
   findAll,
-  findByServerId
+  findByServerId,
+  getServerId
 };
+
+module.exports = service;
 
 class ServerStatus {
   constructor(obj) {
     this.id = obj.id;
+    this.type = obj.type;
     this.alive = obj.alive;
     this.start = obj.start;
     this.revision = obj.revision;
@@ -34,6 +42,10 @@ class ServerStatus {
     } else {
       return 'offline';
     }
+  }
+
+  getShortName() {
+    return this.type + '/' + this.id.slice(-6);
   }
 }
 
@@ -58,24 +70,54 @@ function listenToServerStatusData(zervInstance) {
       }
     }
   });
+
+  // delete dead server after a while. what is the point of seeing the server in the active list offline.
+  // by default let's keep them an hour
+  const clearDeadServerInSecs = process.env.ZERV_DEAD_SERVER_CLEAR_IN_SECS || (60 * 60);
+  setInterval(
+      () => {
+        const list = service.findAll();
+        _.forEach(list, (serverStatus) => {
+          if (!serverStatus.isAlive() && moment.duration(moment().diff(serverStatus.alive)).asSeconds() > clearDeadServerInSecs ) {
+            delete serverStatuses[serverStatus.id];
+          }
+        });
+      },
+      clearDeadServerInSecs * 1000 / 2
+  );
 }
 
 /**
- * create and notify a server status object to the whole zerv cluster
+ * notify this server status periodically
+ * so that other servers will know if a process is no longer handled properly
+ */
+function notifyServerStatusPeriodically() {
+  setInterval(() => {
+    const serverStatus = service.findByServerId(thisServerId);
+    // need to reduce excessive amount of data...
+    serverStatus.activeProcesses= zerv.getActivitiesInProcess();
+    serverStatus.userSessions = zerv.getLocalUserSessions();
+    service.updateOne(serverStatus);
+  }, service.findByServerId(thisServerId).timeout*1000/2);
+}
+
+/**
+ * create this server status and notify a server status object to the whole zerv cluster
  * It is useful for notifying the current load of the server for monitoring purposes.
  *
- * @param {String} serverUniqId
+ * @param {String} type
  * @param {Number} timeout  which is the number of seconds before a server is considered not responsive.
  */
-function createOne(serverUniqId, timeout) {
+function createOne(type, timeout) {
   const serverStatus = new ServerStatus({
-    id: serverUniqId,
+    id: thisServerId,
+    type,
     alive: new Date(),
     revision: Date.now(), // important on server restart
     start: new Date(),
     timeout
   });
-  serverStatuses[serverUniqId] = serverStatus;
+  serverStatuses[serverStatus.id] = serverStatus;
   zerv.notifyCreation('cluster', 'SERVER_STATUS_DATA', serverStatus, {allServers: true});
 
   return serverStatus;
@@ -93,4 +135,8 @@ function findAll() {
 
 function findByServerId(serverId) {
   return serverStatuses[serverId];
+}
+
+function getServerId() {
+  return thisServerId;
 }

--- a/lib/zerv-distrib.js
+++ b/lib/zerv-distrib.js
@@ -40,10 +40,14 @@ _.forIn(require.cache, function(required) {
 if (zervDistrib) {
   module.exports = zervDistrib;
 } else {
+  const IoRedis = require('ioredis');
+
   const processMonitorClient = require('./process-monitor-client.service');
   const processMonitorServer = require('./process-monitor-server.service');
   const processService = require('./process.service');
   const serverStatusService = require('./server-status.service');
+
+  let redisClient;
 
   const service = {
     setCustomProcessImpl,
@@ -52,11 +56,15 @@ if (zervDistrib) {
     monitorQueue: processMonitorServer.monitorQueue,
     addProcessType: processMonitorServer.addProcessType,
     formatClusterStatus,
-    getServerId: processMonitorServer.getServerId
+    getServerId: processMonitorServer.getServerId,
+    getRedisClient
   };
 
   zervCore.addModule('Distrib', service);
 
+  processService.setZervDependency(zervCore);
+  processMonitorClient.setZervDependency(zervCore);
+  processMonitorServer.setZervDependency(zervCore);
 
   module.exports = service;
 
@@ -116,20 +124,42 @@ if (zervDistrib) {
     }, exitDelay * 1000);
   };
 
-  function setCustomProcessImpl(impl) {
-    processService.setProcessService(impl, zervCore);
-    processMonitorClient.setProcessService(processService, zervCore);
-    processMonitorServer.setProcessService(processService, zervCore);
+  // starting point needs to be revised
+  function setCustomProcessImpl() {
     serverStatusService.listenToServerStatusData(zervCore);
   }
 
+  /**
+   * this returns a redis client.
+   * This function should be in zerv-sync comming from the cluster source code which declares on already.
+   *
+   * @returns {IoRedis}
+   */
+  function getRedisClient() {
+    if (!redisClient && process.env.REDIS_ENABLED === 'true') {
+      // --------------------------
+      // Later on, let's use instead the redis client initalized in zerv-sync/clustering
+      // if there were any error, zerv-sync will throw errors anyway
+      const connectionParams = {
+        port: process.env.REDIS_PORT || 6379,
+        host: process.env.REDIS_HOST || '127.0.0.1',
+      };
+      redisClient = new IoRedis(connectionParams);
+      // --------------------------
+    }
+    return redisClient;
+  }
+
   async function formatClusterStatus(findTenandByIdFn) {
+    if (_.isEmpty(getRedisClient())) {
+      return 'Redis client is disabled';
+    }
     const tenantCache = {};
     const colors = {};
     colors[processService.PROCESS_STATUSES.IN_PROGRESS] = 'green';
     colors[processService.PROCESS_STATUSES.COMPLETE] = 'black';
     colors[processService.PROCESS_STATUSES.ERROR] = 'red';
-
+    const serverStatuses = await serverStatusService.findAll();
     return (`<!doctype html>
     <html>
     <body>
@@ -150,7 +180,7 @@ if (zervDistrib) {
     }
 
     async function getServerStatusRows() {
-      const statuses = _.orderBy(await serverStatusService.findAll(), s => s.id);
+      const statuses = _.orderBy(serverStatuses, s => s.id);
       return (await Promise.all(_.map(statuses, formatServerStatus))).join('');
     }
 
@@ -165,9 +195,19 @@ if (zervDistrib) {
     async function formatProcess(p) {
       const color = _.get(colors, p.status, 'grey');
       const tenant = await findTenandById(p.tenantId);
+      const serverStatus = _.find(serverStatuses, {id: p.serverId});
+      let serverName;
+      if (serverStatus) {
+        serverName = serverStatus.getShortName();
+      } else if (p.serverId) {
+        // this server does not exist or has not signaled its presence to this server yet.
+        serverName = 'offline server/' + p.serverId.slice(-8);
+      } else {
+        serverName = '';
+      }
       return `
-        <tr><td rowspan=2>${p.start ? moment(p.start).format('MMM Do, hh:mm:ss A') : ''}</td><td rowspan=2>${p.type}<br/>${p.name}<br/><b>${tenant.display}</b></td><td><span style="color:${color};font-weight:bold">${p.status}</span></td><td>${p.duration} seconds</td><td>${p.serverId || ''}</td></tr>
-        <tr><td colspan=3>${p.progressDescription || ''} ${p.error ? `<br/>${p.error.description || p.error.message}` : ''} </td></tr>
+        <tr><td rowspan=2>${p.start ? moment(p.start).format('MMM Do, hh:mm:ss A') : ''}</td><td rowspan=2>${p.type}<br/>${p.name}<br/><b>${tenant.display}</b></td><td><span style="color:${color};font-weight:bold">${p.status}</span> - ${p.end ? 'ended at ' + moment(p.end).format('hh:mm:ss A') : ''}</td><td>${p.duration} seconds</td><td>${serverName}</td></tr>
+        <tr><td colspan=3>${p.progressDescription || ''} ${p.error ? '<br/>Err: ' + (p.error.description || p.error.message) : ''} </td></tr>
         `;
     }
 
@@ -194,7 +234,7 @@ if (zervDistrib) {
         userSessions.push(`${tenant.display}[${users}]`);
       }
       return `
-        <tr><td rowspan=2 width="250px";>${s.id}</td><td>${moment(s.alive).format('MMM Do, hh:mm:ss A')}</td><td>${s.getStateDisplay()}<br/>Running processes: ${s.activeProcesses.length}</td></tr>
+        <tr><td rowspan=2 width="250px";>${s.getShortName()}</td><td>Start: ${moment(s.start).format('MMM Do, hh:mm:ss A')}<br/>Last update: ${moment(s.alive).format('MMM Do, hh:mm:ss A')}</td><td>${s.getStateDisplay()}<br/>Running processes: ${s.activeProcesses.length}</td></tr>
         <tr><td colspan=2 height="40px"><b>Processes</b>: ${processGroups}<br\><b>Users</b>: ${userSessions}</td></tr>
       `;
     }


### PR DESCRIPTION
- removed The code that was heavily relying on providing an implementation of the queue persistence (based on Postgres) which added load on our app db.
- only use redis
- fix server names as log was very confusing when the server runs in docker (all servers under docker would have the same name)

Code is still a proof of concept and indirectly by-passed by our application demo mode option.
UNIT TESTS are coming from a different branch.
